### PR TITLE
Deprecated method "OpenSSL::Digest::Digest"

### DIFF
--- a/app/controllers/disco_app/app_proxy_controller.rb
+++ b/app/controllers/disco_app/app_proxy_controller.rb
@@ -24,7 +24,7 @@ module DiscoApp
         query_hash = Rack::Utils.parse_query(request.query_string)
         signature = query_hash.delete("signature")
         sorted_params = query_hash.collect{ |k, v| "#{k}=#{Array(v).join(',')}" }.sort.join
-        calculated_signature = OpenSSL::HMAC.hexdigest(OpenSSL::Digest::Digest.new('sha256'), ShopifyApp.configuration.secret, sorted_params)
+        calculated_signature = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'), ShopifyApp.configuration.secret, sorted_params)
         signature == calculated_signature
       end
 

--- a/app/controllers/disco_app/carrier_request_controller.rb
+++ b/app/controllers/disco_app/carrier_request_controller.rb
@@ -18,7 +18,7 @@ module DiscoApp
         return true unless Rails.env.production?
         data = request.body.read.to_s
         hmac_header = request.headers['HTTP_X_SHOPIFY_HMAC_SHA256']
-        digest  = OpenSSL::Digest::Digest.new('sha256')
+        digest  = OpenSSL::Digest.new('sha256')
         calculated_hmac = Base64.encode64(OpenSSL::HMAC.digest(digest, ShopifyApp.configuration.secret, data)).strip
         request.body.rewind
         calculated_hmac == hmac_header


### PR DESCRIPTION
@gavinballard I updated deprecated method "OpenSSL::Digest::Digest" by "OpenSSL::Digest".

Related to issue: https://github.com/discolabs/disco_app/issues/28
