### PR TITLE
Closes #105 : Add endpoint to auth/failure from omniauth

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,6 +7,11 @@ class SessionsController < ApplicationController
     redirect_to root_path
   end
 
+  def failure
+    flash[:notice] = 'There was an issue while trying to authenticate, please retry'
+    redirect_to root_path
+  end
+
   protected
 
     # Override the authenticate method to allow skipping OAuth in development

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ require 'sidekiq/web'
 DiscoApp::Engine.routes.draw do
 
   get 'ref', to: '/sessions#referral'
+  get '/auth/failure', to: '/sessions#failure'
 
   controller :webhooks do
     post 'webhooks' => :process_webhook, as: :webhooks


### PR DESCRIPTION
I am unsure if this is the right controller, will the session controller be mounted on the new app, or should this belong to the `authenticated_controller` in the concerns ?

I will update the changelog upon your review !