### PR TITLE
Closes #178: updating rubocop rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -123,9 +123,6 @@ Style/EachWithObject:
   Description: 'Prefer `each_with_object` over `inject` or `reduce`.'
   Enabled: false
 
-Style/EmptyLinesAroundClassBody:
-  Enabled: false
-
 Style/EmptyLiteral:
   Description: 'Prefer literals to Array.new/Hash.new/String.new.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#literal-array-hash'

--- a/lib/generators/disco_app/templates/root/.rubocop.yml
+++ b/lib/generators/disco_app/templates/root/.rubocop.yml
@@ -123,9 +123,6 @@ Style/EachWithObject:
   Description: 'Prefer `each_with_object` over `inject` or `reduce`.'
   Enabled: false
 
-Style/EmptyLinesAroundClassBody:
-  Enabled: false
-
 Style/EmptyLiteral:
   Description: 'Prefer literals to Array.new/Hash.new/String.new.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#literal-array-hash'


### PR DESCRIPTION
Updating the rubocop rules for the generator and the actual rubocop file. 

Had to update a few things based on the way that rubcop namespaces so to clarify, the rules that I have changed or updated are. 

```
Layout/EmptyLinesAroundClassBody:
  Enabled: true
  EnforcedStyle: empty_lines

Layout/IndentHash:
  Enabled: true
  EnforcedStyle: consistent

Layout/AccessModifierIndentation:
  Enabled: true

Bundler/OrderedGems:
  Enabled: false
```