### PR TITLE
Closes #190 Add subscription instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Finally, you'll want to add a subscription. Subscriptions are covered in more de
 
 ```
 DiscoApp::Plan.find_or_create_by(
-  name: 'put app name here',
+  name: 'My Free App',
   amount: 0,
   trial_period_days: 0
 )


### PR DESCRIPTION
Not sure I've fully understood the relationship between, plans, apps, and subscriptions, so please let me know if what I've written isn't clear/true. 

Also, is there something nicer than 'put name here'? Could we set @app_name at the top of the file maybe? 