### PR TITLE
updating test_helper generation

### DIFF
--- a/lib/generators/disco_app/disco_app_generator.rb
+++ b/lib/generators/disco_app/disco_app_generator.rb
@@ -193,7 +193,16 @@ class DiscoAppGenerator < Rails::Generators::Base
 
   # Add the Disco App test helper to test/test_helper.rb
   def add_test_helper
-    inject_into_file 'test/test_helper.rb', "require 'disco_app/test_help'\n", { after: "require 'rails/test_help'\n" }
+    requirements = <<-TEST_HELPER.strip_heredoc
+                     require 'disco_app/test_help'
+                     require 'minitest/reporters'
+                     require 'minitest/autorun'
+
+                     MiniTest::Reporters.use!
+                     Minitest::Test.make_my_diffs_pretty!
+                   TEST_HELPER
+
+    inject_into_file 'test/test_helper.rb', requirements, after: "require 'rails/test_help'\n"
   end
 
   # Copy engine migrations over.


### PR DESCRIPTION
Updating the `test_helper.rb` generator to make Minitest output a bit prettier

`minitest/reporters` & `minitest/autorun` required for proper test output in RubyMine. Also has the advantage of making tests from the command line a bit prettier.

`Minitest::Test.make_my_diffs_pretty!` uses a better engine for comparing hashes so you can more easily see the difference between two hashes. It has a slight performance cost, but I think this is worth it to speed up development. 

Tom