### PR TITLE
make rubocop prefer find over detect

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -67,7 +67,7 @@ Style/ClassVars:
 Style/CollectionMethods:
   Enabled: true
   PreferredMethods:
-    find: find
+    detect: find
     inject: reduce
     collect: map
     find_all: select


### PR DESCRIPTION
Super tiny change that has been pissing me off for months. 

fixes Rubocop misconfiguration which was causing it to raise an error when you use `find` - 'Prefer `find` over `find`'

I am at last at peace.