### PR TITLE
Closes #214: Include dot files in gemspec file list

### DIFF
--- a/disco_app.gemspec
+++ b/disco_app.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.description = "Rails engine for Shopify applications."
   s.license     = "None"
 
-  s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
+  s.files = Dir["{app,config,db,lib}/**/{*,.*}", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
 
   s.add_runtime_dependency 'rails', '~> 5.1'


### PR DESCRIPTION
See #214.

<img width="1200" alt="screenshot 2018-04-14 14 21 49" src="https://user-images.githubusercontent.com/5946/38764280-5d1f3120-3fef-11e8-844f-9a20eb6e0d61.png">
