### PR TITLE
v0.14.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 No unreleased changes.
 
+## 0.14.3 - 2018-05-02
+### Changed
+- Loosely set the Rails version to '~> 5.1.0' to allow minor patches
+
 ## 0.14.2 - 2018-04-16
 ### Added
 - New initialise.sh script to make starting applications a single command.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,6 +3,9 @@ This file contains more detailed instructions on what's required when updating
 an application between one release version of the gem to the next. It's intended
 as more in-depth accompaniment to the notes in `CHANGELOG.md` for each version.
 
+## Upgrading from 0.14.2 to 0.14.3
+No changes required.
+
 ## Upgrading from 0.14.1 to 0.14.2
 No changes required.
 

--- a/initialise.sh
+++ b/initialise.sh
@@ -4,7 +4,7 @@
 APP_NAME="$1"
 RAILS_VERSION="${2:-5.1.0}"
 RUBY_VERSION="${2:-2.5.0}"
-DISCO_APP_VERSION="${3:-0.14.2}"
+DISCO_APP_VERSION="${3:-0.14.3}"
 
 if [ -z $APP_NAME ]; then
   echo "Usage: ./initialise.sh app_name (rails_version) (ruby_version) (disco_app_version)"

--- a/lib/disco_app/version.rb
+++ b/lib/disco_app/version.rb
@@ -1,3 +1,3 @@
 module DiscoApp
-  VERSION = '0.14.2'
+  VERSION = '0.14.3'
 end


### PR DESCRIPTION
Loosely sets the Rails version to `'~> 5.1.0'` to allow minor patches