### PR TITLE
Supress webhooks output in tests

### DIFF
--- a/test/jobs/disco_app/synchronise_webhooks_job_test.rb
+++ b/test/jobs/disco_app/synchronise_webhooks_job_test.rb
@@ -13,30 +13,46 @@ class DiscoApp::SynchroniseWebhooksJobTest < ActionController::TestCase
   end
 
   test 'webhook synchronisation job creates webhooks for all expected topics' do
-    stub_request(:get, "#{@shop.admin_url}/webhooks.json").to_return(status: 200, body: api_fixture('widget_store/webhooks').to_json)
-    stub_request(:post, "#{@shop.admin_url}/webhooks.json").to_return(status: 200)
+    with_suppressed_output do
+      stub_request(:get, "#{@shop.admin_url}/webhooks.json").to_return(status: 200, body: api_fixture('widget_store/webhooks').to_json)
+      stub_request(:post, "#{@shop.admin_url}/webhooks.json").to_return(status: 200)
 
-    perform_enqueued_jobs do
-      DiscoApp::SynchroniseWebhooksJob.perform_later(@shop)
-    end
+      perform_enqueued_jobs do
+        DiscoApp::SynchroniseWebhooksJob.perform_later(@shop)
+      end
 
-    # Assert that all 4 expected webhook topics were POSTed to.
-    ['app/uninstalled', 'shop/update', 'orders/create', 'orders/paid'].each do |expected_webhook_topic|
-      assert_requested(:post, "#{@shop.admin_url}/webhooks.json", times: 1) { |request| request.body.include?(expected_webhook_topic) }
+      # Assert that all 4 expected webhook topics were POSTed to.
+      ['app/uninstalled', 'shop/update', 'orders/create', 'orders/paid'].each do |expected_webhook_topic|
+        assert_requested(:post, "#{@shop.admin_url}/webhooks.json", times: 1) { |request| request.body.include?(expected_webhook_topic) }
+      end
     end
   end
 
   test 'returns error messages for webhooks that cannot be registered' do
     VCR.use_cassette('webhook_failure') do
-      output = capture_io do
-        perform_enqueued_jobs do
-          DiscoApp::SynchroniseWebhooksJob.perform_later(@shop)
+      with_suppressed_output do
+        output = capture_io do
+          perform_enqueued_jobs do
+            DiscoApp::SynchroniseWebhooksJob.perform_later(@shop)
+          end
         end
-      end
 
-      assert output.first.include?('Invalid topic specified.')
-      assert output.first.include?('orders/create - not registered')
-    end
+        assert output.first.include?('Invalid topic specified.')
+        assert output.first.include?('orders/create - not registered')
+      end
+    end 
   end
+  
+  private
+    # Prevents the output from the webhook synchronisation from 
+    # printing to STDOUT and messing up the test output
+    def with_suppressed_output
+      original_stdout = $stdout.clone
+      $stdout.reopen(File.new('/dev/null', 'w'))
+      yield
+    ensure
+      $stdout.reopen(original_stdout)
+    end
 
 end
+

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -48,7 +48,7 @@ end
 # Minitest helpers to give a better formatted and more helpful output in Rubymine
 require 'minitest/reporters'
 require 'minitest/autorun'
-MiniTest::Reporters.use!
+MiniTest::Reporters.use! Minitest::Reporters::SpecReporter.new
 
 # Set up the base test class.
 class ActiveSupport::TestCase
@@ -67,5 +67,4 @@ class ActiveSupport::TestCase
     session[:shopify] = nil
     session[:shopify_domain] = nil
   end
-
 end


### PR DESCRIPTION
### Description
The webhook synchronisation service produces output which is useful IRL but not in tests.
This suppresses the output int the context of tests. 

### Checklist

- [ ] Updated README and any other relevant documentation.
- [ ] Tested changes locally.
- [x] Updated test suite and made sure that it all passes.
- [ ] Ensured that Rubocop and friends are happy.
- [x] Checked that this PR is referencing the correct base.
