### PR TITLE
pm#166 | Exit controller action after using `head', handle unknown to…

### DIFF
--- a/app/controllers/disco_app/concerns/webhooks_controller.rb
+++ b/app/controllers/disco_app/concerns/webhooks_controller.rb
@@ -13,15 +13,17 @@ module DiscoApp::Concerns::WebhooksController
 
     # Ensure a domain was provided in the headers.
     unless shopify_domain
-      head :bad_request
+      return head :bad_request
     end
 
     # Try to find a matching background job task for the given topic using class name.
     job_class = DiscoApp::WebhookService.find_job_class(topic)
 
-    # Return bad request if we couldn't match a job class.
+    # Return when we don't have the matching job class (a topic that
+    # can't be currently dealt with).  It's important to not return an
+    # error otherwise the webhook may be removed by Shopify.
     unless job_class.present?
-      head :bad_request
+      return render body: nil
     end
 
     # Decode the body data and enqueue the appropriate job.

--- a/test/controllers/disco_app/webhooks_controller_test.rb
+++ b/test/controllers/disco_app/webhooks_controller_test.rb
@@ -55,4 +55,13 @@ class DiscoApp::WebhooksControllerTest < ActionController::TestCase
     end
   end
 
+  test 'webhook request for unknown topic returns success' do
+    body = '{}'
+    @request.headers['HTTP_X_SHOPIFY_TOPIC'] = :'app/unknown'
+    @request.headers['HTTP_X_SHOPIFY_SHOP_DOMAIN'] = @shop.shopify_domain
+    @request.headers['HTTP_X_SHOPIFY_HMAC_SHA256'] = DiscoApp::WebhookService.calculated_hmac(body, ShopifyApp.configuration.secret)
+    post :process_webhook, body: body
+    assert_response :ok
+  end
+
 end


### PR DESCRIPTION
This commit fixes two bugs in the webhooks controller:

  * Use `return' to exit the controller action when calling `head'.

    This is necessary so the rest of the action does not get
    executed.  In the case of unsupported topics, this would cause a
    `nil' job class to be used and thus an exception raised.

  * Don't return an error for unsupported topics.

    If a webhook was registered for topics that can't actually be
    handled, the controller should still return 200 so that Shopfiy
    doesn't remove the webhook for other (valid) topics.