### PR TITLE
Lock shopify_api to avoid breaking changes

### DIFF
--- a/disco_app.gemspec
+++ b/disco_app.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'jquery-rails', '~> 4.3'
   s.add_runtime_dependency 'turbolinks', '~> 5.0'
   s.add_runtime_dependency 'shopify_app', '~> 7.2', '>= 7.2.3'
+  s.add_runtime_dependency 'shopify_api', '~> 6.0'
   s.add_runtime_dependency 'puma', '~> 3.9'
   s.add_runtime_dependency 'sidekiq', '~> 5.0'
   s.add_runtime_dependency 'pg', '~> 0.21.0'


### PR DESCRIPTION
### Description
This PR locks `shopify_api` at v6, since v7 introduces breaking changes.

### Checklist

- [ ] Updated README and any other relevant documentation.
- [ ] Tested changes locally.
- [ ] Updated test suite and made sure that it all passes.
- [ ] Ensured that Rubocop and friends are happy.
- [ ] Checked that this PR is referencing the correct base.
