### PR TITLE
Use with_indifferent_access when reading Flow properties

### DIFF
--- a/app/models/disco_app/flow/concerns/action.rb
+++ b/app/models/disco_app/flow/concerns/action.rb
@@ -15,6 +15,10 @@ module DiscoApp
             succeeded: 1,
             failed: 2
           }
+
+          def properties
+            read_attribute(:properties).with_indifferent_access
+          end
         end
 
       end

--- a/app/models/disco_app/flow/concerns/trigger.rb
+++ b/app/models/disco_app/flow/concerns/trigger.rb
@@ -15,6 +15,10 @@ module DiscoApp
             succeeded: 1,
             failed: 2
           }
+
+          def properties
+            read_attribute(:properties).with_indifferent_access
+          end
         end
 
       end


### PR DESCRIPTION
Clubhouse: N/A

### Description
Fixes an issue arising when we're processing Shopify Flow triggers or actions and we assume that the `.properties` attribute on the trigger or action model can be accessed using symbols, eg instead of:

```
flow_action.properties[:customer_email] # => nil
```

we now get:

```
flow_action.properties[:customer_email] # => "gavin@discolabs.com"
```

### Notes
* N/A

### Checklist

- [ ] Updated README and any other relevant documentation.
- [x] Tested changes locally.
- [x] Updated test suite and made sure that it all passes.
- [ ] Updated test matrix.
- [x] Ensured that Rubocop and friends are happy.
- [x] Checked that this PR is referencing the correct base.
- [ ] Logged all time in Clockify.