### PR TITLE
CH5345: Switch disco_app from minitest to RSpec

### DIFF
--- a/lib/generators/disco_app/install/install_generator.rb
+++ b/lib/generators/disco_app/install/install_generator.rb
@@ -236,11 +236,6 @@ module DiscoApp
         remove_dir 'test'
       end
 
-      # Add the Disco App test helper to test/test_helper.rb
-      def add_test_helper
-        inject_into_file 'test/test_helper.rb', "require 'disco_app/test_help'\n", after: "require 'rails/test_help'\n"
-      end
-
       # Copy engine migrations over.
       def install_migrations
         rake 'disco_app:install:migrations'


### PR DESCRIPTION
ch: [5345](https://app.clubhouse.io/disco/story/5345/switch-disco-app-from-minitest-to-rspec)

### Description
- Remove `add_test_helper` method from `install_generator.rb` as it is no longer necessary and prevents the `discoapp:install` generator from finishing.

### Notes
* The `discoapp:install` generator was actually not being run completely as the `add_test_helper` method was still present. This method looks for a file within the `test` directory which was removed.

### Checklist

- [ ] Updated README and any other relevant documentation.
- [X] Tested changes locally.
- [ ] Updated test suite and made sure that it all passes.
- [X] Ensured that Rubocop and friends are happy.
- [X] Checked that this PR is referencing the correct base.
