### PR TITLE
CH5426: Update disco_app to use latest Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,13 @@
+require: 
+  - rubocop-rails
+  - rubocop-performance
+
 AllCops:
   Exclude:
     - bin/*
     - db/schema.rb
     - vendor/ruby/**/*
+    - node_modules/**/*
   TargetRubyVersion: 2.5
 
 # Layout
@@ -46,6 +51,7 @@ Layout/ClassStructure:
   ExpectedOrder:
     - module_inclusion
     - constants
+    - public_attributes
     - associations
     - validations
     - callbacks
@@ -53,6 +59,7 @@ Layout/ClassStructure:
     - initializer
     - public_methods
     - protected_methods
+    - private_attributes
     - private_methods
   Enabled: true
 
@@ -83,7 +90,7 @@ Layout/IndentFirstHashElement:
   EnforcedStyle: consistent
 
 Layout/IndentationConsistency:
-  EnforcedStyle: rails
+  EnforcedStyle: indented_internal_methods
   Enabled: true
 
 Layout/MultilineBlockLayout:
@@ -238,11 +245,6 @@ Style/FrozenStringLiteralComment:
     to help transition from Ruby 2.3.0 to Ruby 3.0.
   Enabled: false
 
-Lint/FlipFlop:
-  Description: 'Checks for flip flops'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-flip-flops'
-  Enabled: true
-
 Style/FormatString:
   Description: 'Enforce the use of Kernel#sprintf, Kernel#format or String#%.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#sprintf'
@@ -381,6 +383,13 @@ Style/RaiseArgs:
 Style/RegexpLiteral:
   Description: 'Use / or %r around regular expressions.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-r'
+  Enabled: true
+
+Style/Sample:
+  Description: >-
+                  Use `sample` instead of `shuffle.first`,
+                  `shuffle.last`, and `shuffle[Fixnum]`.
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#arrayshufflefirst-vs-arraysample-code'
   Enabled: true
 
 Style/SelfAssignment:
@@ -568,6 +577,11 @@ Lint/ElseLayout:
   Description: 'Check for odd code arrangement in an else block.'
   Enabled: true
 
+Lint/FlipFlop:
+  Description: 'Checks for flip flops'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-flip-flops'
+  Enabled: true
+
 Lint/FormatParameterMismatch:
   Description: 'The number of parameters to format/sprint must match the fields.'
   Enabled: true
@@ -657,13 +671,6 @@ Performance/ReverseEach:
   Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerablereverseeach-vs-enumerablereverse_each-code'
   Enabled: true
 
-Style/Sample:
-  Description: >-
-                  Use `sample` instead of `shuffle.first`,
-                  `shuffle.last`, and `shuffle[Fixnum]`.
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#arrayshufflefirst-vs-arraysample-code'
-  Enabled: true
-
 Performance/Size:
   Description: >-
                   Use `size` instead of `count` for counting
@@ -695,6 +702,10 @@ Rails/Delegate:
   Description: 'Prefer delegate method for delegations.'
   Enabled: false
 
+Rails/Exit:
+  Exclude:
+    - lib/generators/disco_app/install/templates/spec/rails_helper.rb
+
 Rails/FindBy:
   Description: 'Prefer find_by over where.first.'
   Enabled: true
@@ -709,7 +720,11 @@ Rails/HasAndBelongsToMany:
 
 Rails/Output:
   Description: 'Checks for calls to puts, print, etc.'
-  Enabled: true
+  Enabled: false
+
+Rails/HttpPositionalArguments:
+  Description: 'Use keyword arguments instead of positional arguments for http calls'
+  Enabled: false
 
 Rails/ReadWriteAttribute:
   Description: >-
@@ -726,6 +741,13 @@ Rails/TimeZone:
   StyleGuide: 'https://github.com/bbatsov/rails-style-guide#time'
   Reference: 'http://danilenko.org/2012/7/6/rails_timezones'
   Enabled: true
+
+Rails/UnknownEnv:
+  Environments:
+    - development
+    - production
+    - staging
+    - test
 
 Rails/Validation:
   Description: 'Use validates :attribute, hash of validations.'

--- a/app/clients/disco_app/api_client.rb
+++ b/app/clients/disco_app/api_client.rb
@@ -10,7 +10,7 @@ class DiscoApp::ApiClient
   end
 
   def create_app_subscription
-    return unless @url.present?
+    return if @url.blank?
 
     url = @url + SUBSCRIPTION_ENDPOINT
     begin

--- a/app/controllers/disco_app/admin/concerns/app_settings_controller.rb
+++ b/app/controllers/disco_app/admin/concerns/app_settings_controller.rb
@@ -8,7 +8,7 @@ module DiscoApp::Admin::Concerns::AppSettingsController
 
   def update
     @app_settings = DiscoApp::AppSettings.instance
-    if @app_settings.update_attributes(app_settings_params)
+    if @app_settings.update(app_settings_params)
       flash[:success] = 'Settings updated.'
       redirect_to edit_admin_app_settings_path
     else

--- a/app/controllers/disco_app/admin/concerns/plans_controller.rb
+++ b/app/controllers/disco_app/admin/concerns/plans_controller.rb
@@ -27,7 +27,7 @@ module DiscoApp::Admin::Concerns::PlansController
   end
 
   def update
-    if @plan.update_attributes(plan_params)
+    if @plan.update(plan_params)
       redirect_to edit_admin_plan_path(@plan)
     else
       render 'edit'

--- a/app/controllers/disco_app/admin/concerns/sources_controller.rb
+++ b/app/controllers/disco_app/admin/concerns/sources_controller.rb
@@ -27,7 +27,7 @@ module DiscoApp::Admin::Concerns::SourcesController
   end
 
   def update
-    if @source.update_attributes(source_params)
+    if @source.update(source_params)
       redirect_to edit_admin_plan_path(@source)
     else
       render 'edit'

--- a/app/controllers/disco_app/admin/concerns/subscriptions_controller.rb
+++ b/app/controllers/disco_app/admin/concerns/subscriptions_controller.rb
@@ -10,7 +10,7 @@ module DiscoApp::Admin::Concerns::SubscriptionsController
   end
 
   def update
-    if @subscription.update_attributes(subscription_params)
+    if @subscription.update(subscription_params)
       redirect_to edit_admin_shop_subscription_path(@subscription.shop, @subscription)
     else
       render 'edit'
@@ -20,7 +20,7 @@ module DiscoApp::Admin::Concerns::SubscriptionsController
   private
 
     def find_subscription
-      @subscription = DiscoApp::Subscription.find_by_id(params[:id])
+      @subscription = DiscoApp::Subscription.find_by(id: params[:id])
     end
 
     def subscription_params

--- a/app/controllers/disco_app/charges_controller.rb
+++ b/app/controllers/disco_app/charges_controller.rb
@@ -39,7 +39,7 @@ class DiscoApp::ChargesController < ApplicationController
   private
 
     def find_subscription
-      @subscription = @shop.subscriptions.find_by_id!(params[:subscription_id])
+      @subscription = @shop.subscriptions.find_by!(id: params[:subscription_id])
       redirect_to main_app.root_url unless @subscription.requires_active_charge? && !@subscription.active_charge?
     end
 

--- a/app/controllers/disco_app/concerns/app_proxy_controller.rb
+++ b/app/controllers/disco_app/concerns/app_proxy_controller.rb
@@ -25,7 +25,7 @@ module DiscoApp::Concerns::AppProxyController
     end
 
     def shopify_shop
-      @shop = DiscoApp::Shop.find_by_shopify_domain!(params[:shop])
+      @shop = DiscoApp::Shop.find_by!(shopify_domain: params[:shop])
     end
 
     def add_liquid_header

--- a/app/controllers/disco_app/concerns/authenticated_controller.rb
+++ b/app/controllers/disco_app/concerns/authenticated_controller.rb
@@ -20,8 +20,8 @@ module DiscoApp::Concerns::AuthenticatedController
     def auto_login
       return unless shop_session.nil? && request_hmac_valid?
 
-      shop = DiscoApp::Shop.find_by_shopify_domain(sanitized_shop_name)
-      return unless shop.present?
+      shop = DiscoApp::Shop.find_by(shopify_domain: sanitized_shop_name)
+      return if shop.blank?
 
       session[:shopify] = shop.id
       session[:shopify_domain] = sanitized_shop_name
@@ -70,7 +70,7 @@ module DiscoApp::Concerns::AuthenticatedController
 
     def check_shop_whitelist
       return unless shop_session
-      return unless ENV['WHITELISTED_DOMAINS'].present?
+      return if ENV['WHITELISTED_DOMAINS'].blank?
       return if ENV['WHITELISTED_DOMAINS'].include?(shop_session.url)
 
       redirect_to_login

--- a/app/controllers/disco_app/concerns/carrier_request_controller.rb
+++ b/app/controllers/disco_app/concerns/carrier_request_controller.rb
@@ -25,7 +25,7 @@ module DiscoApp::Concerns::CarrierRequestController
     end
 
     def find_shop
-      @shop = DiscoApp::Shop.find_by_shopify_domain(request.headers['HTTP_X_SHOPIFY_SHOP_DOMAIN'])
+      @shop = DiscoApp::Shop.find_by(shopify_domain: request.headers['HTTP_X_SHOPIFY_SHOP_DOMAIN'])
 
       head :unauthorized unless @shop
     end
@@ -35,10 +35,10 @@ module DiscoApp::Concerns::CarrierRequestController
     end
 
     def request_is_valid?
-      return false unless params[:rate].present?
-      return false unless params[:rate][:origin].present?
-      return false unless params[:rate][:destination].present?
-      return false unless params[:rate][:items].present?
+      return false if params[:rate].blank?
+      return false if params[:rate][:origin].blank?
+      return false if params[:rate][:destination].blank?
+      return false if params[:rate][:items].blank?
     end
 
 end

--- a/app/controllers/disco_app/concerns/webhooks_controller.rb
+++ b/app/controllers/disco_app/concerns/webhooks_controller.rb
@@ -19,7 +19,7 @@ module DiscoApp::Concerns::WebhooksController
     job_class = DiscoApp::WebhookService.find_job_class(topic)
 
     # Return bad request if we couldn't match a job class.
-    return head :bad_request unless job_class.present?
+    return head :bad_request if job_class.blank?
 
     # Decode the body data and enqueue the appropriate job.
     data = JSON.parse(request.body.read).with_indifferent_access

--- a/app/controllers/disco_app/flow/concerns/actions_controller.rb
+++ b/app/controllers/disco_app/flow/concerns/actions_controller.rb
@@ -41,7 +41,7 @@ module DiscoApp
           end
 
           def find_shop
-            @shop = DiscoApp::Shop.find_by_shopify_domain!(params[:shopify_domain])
+            @shop = DiscoApp::Shop.find_by!(shopify_domain: params[:shopify_domain])
           end
 
       end

--- a/app/controllers/disco_app/subscriptions_controller.rb
+++ b/app/controllers/disco_app/subscriptions_controller.rb
@@ -11,7 +11,7 @@ class DiscoApp::SubscriptionsController < ApplicationController
   def create
     # Get the selected plan. If it's not available or couldn't be found,
     # redirect back to the plan selection page.
-    plan = DiscoApp::Plan.available.find_by_id(subscription_params[:plan])
+    plan = DiscoApp::Plan.available.find_by(id: subscription_params[:plan])
 
     redirect_to(action: :new) && return unless plan
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -20,7 +20,7 @@ class SessionsController < ActionController::Base
     # by the `shop` parameter to be present in the local database.
     def authenticate
       if Rails.env.development? && DiscoApp.configuration.skip_oauth?
-        shop = DiscoApp::Shop.find_by_shopify_domain!(sanitized_shop_name)
+        shop = DiscoApp::Shop.find_by!(shopify_domain: sanitized_shop_name)
 
         sess = ShopifyAPI::Session.new(shop.shopify_domain, shop.shopify_token)
         session[:shopify] = ShopifyApp::SessionRepository.store(sess)

--- a/app/helpers/disco_app/application_helper.rb
+++ b/app/helpers/disco_app/application_helper.rb
@@ -39,7 +39,7 @@ module DiscoApp::ApplicationHelper
     fields = form.fields_for(association, new_object, child_index: id) do |builder|
       render(association.to_s.singularize + '_fields', f: builder)
     end
-    link_to(name, '#', class: 'add_fields', data: { id: id, fields: fields.gsub("\n", '') })
+    link_to(name, '#', class: 'add_fields', data: { id: id, fields: fields.delete("\n") })
   end
 
   # Return the props required to instantiate a React ModelForm component for the

--- a/app/models/disco_app/concerns/plan.rb
+++ b/app/models/disco_app/concerns/plan.rb
@@ -3,7 +3,7 @@ module DiscoApp::Concerns::Plan
   extend ActiveSupport::Concern
 
   included do
-    has_many :subscriptions
+    has_many :subscriptions, dependent: :restrict_with_exception
     has_many :shops, through: :subscriptions
     has_many :plan_codes, dependent: :destroy
 

--- a/app/models/disco_app/concerns/shop.rb
+++ b/app/models/disco_app/concerns/shop.rb
@@ -7,11 +7,11 @@ module DiscoApp::Concerns::Shop
     include ActionView::Helpers::DateHelper
 
     # Define relationships to plans and subscriptions.
-    has_many :subscriptions
+    has_many :subscriptions, dependent: :restrict_with_exception
     has_many :plans, through: :subscriptions
 
     # Define relationship to users.
-    has_many :users
+    has_many :users, dependent: :restrict_with_exception
 
     # Define relationship to sessions.
     has_many :sessions, class_name: 'DiscoApp::Session', dependent: :destroy

--- a/app/models/disco_app/concerns/source.rb
+++ b/app/models/disco_app/concerns/source.rb
@@ -3,7 +3,7 @@ module DiscoApp::Concerns::Source
   extend ActiveSupport::Concern
 
   included do
-    has_many :subscriptions
+    has_many :subscriptions, dependent: :restrict_with_exception
     has_many :shops, through: :subscriptions
 
     validates_presence_of :source

--- a/app/services/disco_app/charges_service.rb
+++ b/app/services/disco_app/charges_service.rb
@@ -67,7 +67,7 @@ class DiscoApp::ChargesService
   def self.cancel_recurring_charges(shop, charge = nil)
     charges = DiscoApp::RecurringApplicationCharge.where(shop: shop)
     charges = charges.where.not(id: charge) if charge.present?
-    charges.update_all(status: DiscoApp::RecurringApplicationCharge.statuses[:cancelled])
+    charges.update_all(status: DiscoApp::RecurringApplicationCharge.statuses[:cancelled]) # rubocop:disable Rails/SkipsModelValidations
   end
 
 end

--- a/app/services/disco_app/partner_app_service.rb
+++ b/app/services/disco_app/partner_app_service.rb
@@ -79,7 +79,7 @@ module DiscoApp
           form['create_form[application_url]'] = @app_url
 
           # Accept TOS
-          unless form['create_form[accepted]'].blank?
+          if form['create_form[accepted]'].present?
             form['create_form[accepted]'] = '1'
             form.hiddens.last.value = 1
           end

--- a/app/services/disco_app/subscription_service.rb
+++ b/app/services/disco_app/subscription_service.rb
@@ -32,23 +32,23 @@ class DiscoApp::SubscriptionService
 
     # If a plan code was provided, fetch it for the given plan.
     def plan_code_instance
-      return unless plan_code.present?
+      return if plan_code.blank?
 
       @plan_code_instance ||= DiscoApp::PlanCode.available.find_by(plan: plan, code: plan_code)
     end
 
     # If a source name has been provided, fetch or create it
     def source_instance
-      return unless source_name.present?
+      return if source_name.blank?
 
       @source_instance ||= DiscoApp::Source.find_or_create_by(source: source_name)
     end
 
     # Cancel any existing current subscriptions.
     def cancel_existing_subscriptions
-      shop.subscriptions.current.update_all(
+      shop.subscriptions.current.update_all( # rubocop:disable Rails/SkipsModelValidations
         status: DiscoApp::Subscription.statuses[:cancelled],
-        cancelled_at: Time.now
+        cancelled_at: Time.zone.now
       )
     end
 
@@ -71,7 +71,7 @@ class DiscoApp::SubscriptionService
         subscription_type: plan.plan_type,
         amount: subscription_amount,
         trial_period_days: plan.has_trial? ? subscription_trial_period_days : nil,
-        trial_start_at: plan.has_trial? ? Time.now : nil,
+        trial_start_at: plan.has_trial? ? Time.zone.now : nil,
         trial_end_at: plan.has_trial? ? subscription_trial_period_days.days.from_now : nil,
         source: source_instance
       )

--- a/app/services/disco_app/webhook_service.rb
+++ b/app/services/disco_app/webhook_service.rb
@@ -15,11 +15,11 @@ class DiscoApp::WebhookService
   # Try to find a job class for the given webhook topic.
   def self.find_job_class(topic)
     # First try to find a top-level matching job class.
-    "#{topic}_job".gsub('/', '_').classify.constantize
+    "#{topic}_job".tr('/', '_').classify.constantize
   rescue NameError
     # If that fails, try to find a DiscoApp:: prefixed job class.
     begin
-      %(DiscoApp::#{"#{topic}_job".gsub('/', '_').classify}).constantize
+      %(DiscoApp::#{"#{topic}_job".tr('/', '_').classify}).constantize
     rescue NameError
       nil
     end

--- a/db/migrate/20170315062629_add_sources_to_shop_subscriptions.rb
+++ b/db/migrate/20170315062629_add_sources_to_shop_subscriptions.rb
@@ -10,7 +10,7 @@ class AddSourcesToShopSubscriptions < ActiveRecord::Migration[5.1]
       end
     end
 
-    remove_column :disco_app_subscriptions, :source
+    remove_column :disco_app_subscriptions, :source, :string
   end
 
 end

--- a/disco_app.gemspec
+++ b/disco_app.gemspec
@@ -55,7 +55,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'dotenv-rails', '~> 2.0'
   s.add_development_dependency 'minitest', '5.10.1'
   s.add_development_dependency 'minitest-reporters', '1.1.9'
-  s.add_development_dependency 'rubocop', '~> 0.70'
+  s.add_development_dependency 'rubocop', '~> 0.72'
+  s.add_development_dependency 'rubocop-performance', '~> 1.4.0'
+  s.add_development_dependency 'rubocop-rails', '~> 2.2.0'
   s.add_development_dependency 'vcr', '~> 3.0'
   s.add_development_dependency 'webmock', '~> 2.3'
 end

--- a/lib/generators/disco_app/install/install_generator.rb
+++ b/lib/generators/disco_app/install/install_generator.rb
@@ -59,6 +59,12 @@ module DiscoApp
           gem 'rb-readline'
         end
 
+        gem_group :development do
+          gem 'rubocop'
+          gem 'rubocop-performance'
+          gem 'rubocop-rails'
+        end
+
         # Indicate which gems should only be used in development and test.
         gem_group :development, :test do
           gem 'coveralls'
@@ -104,8 +110,13 @@ module DiscoApp
         application '# Ensure UTC is the default timezone'
 
         # Set server side rendereing for components.js
-        application "config.react.server_renderer_options = {\nfiles: ['components.js'], # files to load for prerendering\n}"
-        application '# Enable server side react rendering'
+        application <<~CONFIG
+          # Enable server side react rendering
+          config.react.server_renderer_options = {
+            # files to load for prerendering
+            files: ['components.js']
+          }
+        CONFIG
 
         # Set defaults for various charge attributes.
         application "config.x.shopify_charges_default_trial_days = 14\n"

--- a/lib/generators/disco_app/install/templates/root/.rubocop.yml
+++ b/lib/generators/disco_app/install/templates/root/.rubocop.yml
@@ -1,8 +1,13 @@
+require: 
+  - rubocop-rails
+  - rubocop-performance
+
 AllCops:
   Exclude:
     - bin/*
     - db/schema.rb
     - vendor/ruby/**/*
+    - node_modules/**/*  
   TargetRubyVersion: 2.5
 
 # Layout
@@ -46,7 +51,7 @@ Layout/ClassStructure:
   ExpectedOrder:
     - module_inclusion
     - constants
-    - attributes
+    - public_attributes
     - associations
     - validations
     - callbacks
@@ -54,6 +59,7 @@ Layout/ClassStructure:
     - initializer
     - public_methods
     - protected_methods
+    - private_attributes
     - private_methods
   Enabled: true
 
@@ -84,7 +90,7 @@ Layout/IndentFirstHashElement:
   EnforcedStyle: consistent
 
 Layout/IndentationConsistency:
-  EnforcedStyle: rails
+  EnforcedStyle: indented_internal_methods
   Enabled: true
 
 Layout/MultilineBlockLayout:
@@ -239,11 +245,6 @@ Style/FrozenStringLiteralComment:
     to help transition from Ruby 2.3.0 to Ruby 3.0.
   Enabled: false
 
-Lint/FlipFlop:
-  Description: 'Checks for flip flops'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-flip-flops'
-  Enabled: true
-
 Style/FormatString:
   Description: 'Enforce the use of Kernel#sprintf, Kernel#format or String#%.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#sprintf'
@@ -384,6 +385,13 @@ Style/RegexpLiteral:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-r'
   Enabled: true
 
+Style/Sample:
+  Description: >-
+                  Use `sample` instead of `shuffle.first`,
+                  `shuffle.last`, and `shuffle[Fixnum]`.
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#arrayshufflefirst-vs-arraysample-code'
+  Enabled: true
+
 Style/SelfAssignment:
   Description: >-
                  Checks for places where self-assignment shorthand should have
@@ -491,6 +499,7 @@ Metrics/BlockLength:
     - namespace
     - trait
 
+
 Metrics/BlockNesting:
   Description: 'Avoid excessive block nesting'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#three-is-the-number-thou-shalt-count'
@@ -564,6 +573,11 @@ Lint/EachWithObjectArgument:
 
 Lint/ElseLayout:
   Description: 'Check for odd code arrangement in an else block.'
+  Enabled: true
+
+Lint/FlipFlop:
+  Description: 'Checks for flip flops'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-flip-flops'
   Enabled: true
 
 Lint/FormatParameterMismatch:
@@ -655,13 +669,6 @@ Performance/ReverseEach:
   Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerablereverseeach-vs-enumerablereverse_each-code'
   Enabled: true
 
-Style/Sample:
-  Description: >-
-                  Use `sample` instead of `shuffle.first`,
-                  `shuffle.last`, and `shuffle[Fixnum]`.
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#arrayshufflefirst-vs-arraysample-code'
-  Enabled: true
-
 Performance/Size:
   Description: >-
                   Use `size` instead of `count` for counting
@@ -692,6 +699,10 @@ Rails/Date:
 Rails/Delegate:
   Description: 'Prefer delegate method for delegations.'
   Enabled: false
+
+Rails/Exit:
+  Exclude:
+    - lib/generators/disco_app/install/templates/spec/rails_helper.rb
 
 Rails/FindBy:
   Description: 'Prefer find_by over where.first.'
@@ -724,6 +735,13 @@ Rails/TimeZone:
   StyleGuide: 'https://github.com/bbatsov/rails-style-guide#time'
   Reference: 'http://danilenko.org/2012/7/6/rails_timezones'
   Enabled: true
+
+Rails/UnknownEnv:
+  Environments:
+    - development
+    - production
+    - staging
+    - test
 
 Rails/Validation:
   Description: 'Use validates :attribute, hash of validations.'

--- a/test/services/disco_app/flow/process_action_test.rb
+++ b/test/services/disco_app/flow/process_action_test.rb
@@ -24,7 +24,7 @@ module DiscoApp
           action_run_id: 'bdb15e45-4f9d-4c80-88c8-7b43a24edaac-30892-cc8eb62a-14db-43fc-bc33-d6dea41ae623',
           properties: { 'customer_email' => 'name@example.com' }
         )
-        @now = Time.parse('2018-12-29T00:00:00Z')
+        @now = Time.zone.parse('2018-12-29T00:00:00Z')
         Timecop.freeze(@now)
       end
 

--- a/test/services/disco_app/flow/process_trigger_test.rb
+++ b/test/services/disco_app/flow/process_trigger_test.rb
@@ -14,7 +14,7 @@ module DiscoApp
           resource_url: 'https://example.com/test-resource-url',
           properties: { 'Customer email' => 'name@example.com' }
         )
-        @now = Time.parse('2018-12-29T00:00:00Z')
+        @now = Time.zone.parse('2018-12-29T00:00:00Z')
         Timecop.freeze(@now)
       end
 

--- a/test/services/disco_app/subscription_service_test.rb
+++ b/test/services/disco_app/subscription_service_test.rb
@@ -45,14 +45,14 @@ class DiscoApp::SubscriptionServiceTest < ActiveSupport::TestCase
   test 'new subscription for a plan with a trial period created correctly' do
     new_subscription = DiscoApp::SubscriptionService.subscribe(@shop, disco_app_plans(:premium))
     assert new_subscription.trial?
-    assert_equal Time.now, new_subscription.trial_start_at
+    assert_equal Time.zone.now, new_subscription.trial_start_at
     assert_equal 28.days.from_now, new_subscription.trial_end_at
   end
 
   test 'new subscription for a plan with a plan code created correctly' do
     new_subscription = DiscoApp::SubscriptionService.subscribe(@shop, disco_app_plans(:premium), 'PODCAST')
     assert new_subscription.trial?
-    assert_equal Time.now, new_subscription.trial_start_at
+    assert_equal Time.zone.now, new_subscription.trial_start_at
     assert_equal 60.days.from_now, new_subscription.trial_end_at
     assert_equal 60, new_subscription.trial_period_days
     assert_equal 8999, new_subscription.amount


### PR DESCRIPTION
ch: [5426](https://app.clubhouse.io/disco/story/5426/update-disco-app-to-use-latest-rubocop)

### Description
- Run `rubocop` command to perform safe auto-corrections
- Add `rubocop`, `rubocop-rails` and `rubocop-performance` gems to `install_generator.rb` and `disco_app.gemspec`
- Add `rake` task for running `rubocop` and auto-correct with extensions
- Update `EnforcedStyle: rails` => `EnforcedStyle: indented_internal_methods`
- Update `Performance/Sample` => `Style/Sample`
- Update `Style/FlipFlop` => `Lint/FlipFlop`
- Enable `Style/ClassAndModuleChildren` rule for generated `rubocop.yml` (this means app code should use nested format)
- Disable `Style/ClassAndModuleChildren` rule for this repo's `rubocop.yml` (retains our compact format)
- Exclude `rails_helper.rb` from `Rails/Exit` rule
- Specify environments for `Rails/UnknownEnv` rule, e.g. staging
- Disable `Rails/Output` rule for `.rubocop.yml` file in this repo
- Leave `Rails/Output` rule enabled for generated `.rubocop.yml`
- Add `dependent: :restrict_with_exception` to `has_many` associations where they are not specified
- Disable `Rails/SkipsModelValidations` rule inline for `update_all` method calls
- Add type to `remove_column` method call in migration (allows rollbacks for this particular db change)
- Disable `Rails/HttpPositionalArguments` for this repo's `rubocop.yml` (this was causing tests to fail due to auto-corrections in this repo's `routes.rb`)

### Notes
* Ran `rake test` and all tests are passing as normal.
* We can now run `rake rubocop` and `rake rubocop:auto_correct` tasks for convenience.

### Checklist

- [X] Updated README and any other relevant documentation.
- [X] Tested changes locally.
- [ ] Updated test suite and made sure that it all passes.
- [X] Ensured that Rubocop and friends are happy.
- [X] Checked that this PR is referencing the correct base.
