### PR TITLE
CH6321: Remove Rollbar calls and references in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,21 +78,14 @@ app via the partner dashboard. Before you can do this, you need to configure
 a couple of things.
 
 #### Create a DiscoApp configuration file in your home directory
-First, you'll need to add your partner dashboard and Rollbar credentials to a DiscoApp
-configuration file in your home directory, `~/.disco_app.yml`:
+First, you'll need to add your partner dashboard credentials to a DiscoApp configuration file in your home directory, `~/.disco_app.yml`:
 
 ```
 params:
   PARTNER_EMAIL: "hello@discolabs.com"
   PARTNER_PASSWORD: "***********"
   PARTNER_ORGANIZATION: "Disco"
-  ROLLBAR_ACCOUNT_ACCESS_TOKEN_WRITE: "******************************"
-  ROLLBAR_ACCOUNT_ACCESS_TOKEN_READ: "******************************"
 ```
-
-You can find your tokens in the Rollbar settings under 'Project Access Tokens'.
-If you don't yet have a Rollbar account you can leave out the bottom two lines for now.
-You'll only need to set this up the one time on your local machine.
 
 #### Configure initial values in local ENV file
 Next, you'll need to set a few of the basic configuration parameters for your
@@ -349,7 +342,6 @@ There's a number of useful Rake tasks that are baked into the app. They are:
 - `rake shops:sync`: Synchronises shop data across all installed shops.
 - `rake users:sync`: Synchronises user data across all installed shops.
 - `rake generate:partner_app`: Generates an app on the Disco Partner Dashboard
-- `rake generate:rollbar_project`: Generates a Rollbar Project
 
 ### Background Tasks
 The `DiscoApp::ShopJob` class inherits from `ActiveJob::Base`, and can be used
@@ -955,21 +947,15 @@ Mailgun API in production for sending email. Adds the `MAILGUN_API_KEY` and
 DiscoApp has support for both exception reporting and application performance
 monitoring to the application.
 
-[Rollbar][] is used for exception tracking, and will be activated when a
-`ROLLBAR_ACCESS_TOKEN` environment variable is present. Rollbar access tokens
-are unique to each app. In order to generate a new token run
-`rake generate:rollbar_project`.
-Make sure you have configured your `~/.disco_app.yml` as per
-[the setup guide](#create-a-discoapp-configuration-file-in-your-home-directory)
-and that you have the necessary Rollbar permissions to create a project. You can
-specify an app name by adding APP_NAME='App Name'.
+[Appsignal](https://github.com/appsignal/appsignal-ruby) is used for exception tracking, and will be activated when a
+`APPSIGNAL_PUSH_API_KEY` environment variable is present. The Appsignal Push API Key can be found in 1Password.
 
 [New Relic][] is used for application performance monitoring, and will be
 activated when a `NEW_RELIC_LICENSE_KEY` environment variable is present. There
 is a single New Relic license key across all Disco apps - contact Gavin if you
 need it to deploy a new application.
 
-[Rollbar]: https://www.rollbar.com
+[Appsignal]: https://www.appsignal.com
 [New Relic]: https://www.newrelic.com
 
 

--- a/app/jobs/disco_app/concerns/synchronise_users_job.rb
+++ b/app/jobs/disco_app/concerns/synchronise_users_job.rb
@@ -8,7 +8,7 @@ module DiscoApp::Concerns::SynchroniseUsersJob
         ShopifyAPI::User.all
       end
     rescue ActiveResource::UnauthorizedAccess => e
-      Rollbar.error(e)
+      Appsignal.set_error(e)
       return
     end
 


### PR DESCRIPTION
ch: [6321](https://app.clubhouse.io/disco/story/6321/remove-rollbar-calls-and-references-in-readme)

### Description
- Remove `Rollbar.error` calls and replace with calls to Appsignal gem.
- Remove references to Rollbar in README and replace with references to Appsignal.

### Checklist

- [X] Updated README and any other relevant documentation.
- [ ] Tested changes locally.
- [ ] Updated test suite and made sure that it all passes.
- [X] Ensured that Rubocop and friends are happy.
- [X] Checked that this PR is referencing the correct base.
