### PR TITLE
Gracefully handle cases where data[:tags] is nil

### DIFF
--- a/app/models/disco_app/concerns/taggable.rb
+++ b/app/models/disco_app/concerns/taggable.rb
@@ -3,7 +3,7 @@ module DiscoApp::Concerns::Taggable
   extend ActiveSupport::Concern
 
   def tags
-    data[:tags].split(',').map(&:strip)
+    data[:tags].to_s.split(',').map(&:strip)
   end
 
   def add_tag(tag)


### PR DESCRIPTION
Clubhouse: N/A

### Description
A minor update to handle a case where the `tags` attribute in a taggable object is `nil`.

### Notes
* N/A

### Checklist
- [x] Updated README and any other relevant documentation.
- [x] Tested changes locally.
- [x] Updated test suite and made sure that it all passes.
- [ ] Ensured that Rubocop and friends are happy.
- [x] Checked that this PR is referencing the correct base.
- [ ] Logged all time in Clockify.
